### PR TITLE
[COF-65] fix: userResponseDto에 id를 얻는 method 추가

### DIFF
--- a/src/auth/google-oauth.strategy.ts
+++ b/src/auth/google-oauth.strategy.ts
@@ -53,7 +53,7 @@ export class GoogleOAuthStrategy extends PassportStrategy(Strategy, 'google') {
       user = await this.userService.signUpOAuth(userData, provider, userRole);
     }
 
-    const token = this.authService.sign({ aud: user.id });
+    const token = this.authService.sign({ aud: user.getId() });
 
     done(null, { token: token });
   }

--- a/src/auth/kakao-oauth.strategy.ts
+++ b/src/auth/kakao-oauth.strategy.ts
@@ -46,7 +46,7 @@ export class KakaoOAuthStrategy extends PassportStrategy(Strategy, 'kakao') {
       user = await this.userService.signUpOAuth(userData, provider, userRole);
     }
 
-    const token = this.authService.sign({ aud: user.id });
+    const token = this.authService.sign({ aud: user.getId() });
 
     done(null, { token: token });
   }

--- a/src/auth/token-auth.strategy.ts
+++ b/src/auth/token-auth.strategy.ts
@@ -4,7 +4,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { UserService } from 'src/user/user.service';
-import { User } from 'src/entity/user.entity';
+import { UserResponseDto } from '../user/dto/user-response.dto';
 
 @Injectable()
 export class TokenAuthStrategy extends PassportStrategy(Strategy) {
@@ -19,7 +19,7 @@ export class TokenAuthStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: any): Promise<User> {
+  async validate(payload: any): Promise<UserResponseDto> {
     const userId = payload.aud;
     const user = await this.userService.findUserById(userId);
     if (!user) throw new NotFoundException('USER_NOT_FOUND');

--- a/src/user/dto/user-response.dto.ts
+++ b/src/user/dto/user-response.dto.ts
@@ -29,4 +29,6 @@ export class UserResponseDto {
 
   private mapProviderToDto = (provider: Provider) => ({ id: provider.id });
   private mapUserRoleToDto = (userRole: UserRole) => ({ id: userRole.id });
+
+  getId = () => this.id;
 }


### PR DESCRIPTION
## Objectives
> 이 PR의 목적은 무엇인가요?   
<br>
user response dto에서 id가 private여서 읽을 수 없는 문제 수정

<br>

## Key Results
> 이 PR의 결과물은 어떤것인가요?   
<br>
user response dto에 getId 함수 추가

<br>

## Review Points
> 리뷰 할 때 특별히 이런 부분을 봐주세요.   
<br>
dto class의 method로 적용했는데 적절한지 확인 부탁드려요

<br>